### PR TITLE
Fixes node 12 compilation error

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -10,12 +10,12 @@ namespace {
 
 NAN_METHOD(New) {}
 
-void Init(Handle<Object> exports, Handle<Object> module) {
+void Init(Local<Object> exports, Local<Object> module) {
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
   tpl->SetClassName(Nan::New("Language").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  Local<Function> constructor = tpl->GetFunction();
+  Local<Function> constructor = Nan::GetFunction(tpl).ToLocalChecked();
   Local<Object> instance = constructor->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
   Nan::SetInternalFieldPointer(instance, 0, tree_sitter_embedded_template());
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -19,8 +19,8 @@ void Init(Local<Object> exports, Local<Object> module) {
   Local<Object> instance = constructor->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
   Nan::SetInternalFieldPointer(instance, 0, tree_sitter_embedded_template());
 
-  instance->Set(Nan::New("name").ToLocalChecked(), Nan::New("embedded_template").ToLocalChecked());
-  module->Set(Nan::New("exports").ToLocalChecked(), instance);
+  Nan::Set(instance, Nan::New("name").ToLocalChecked(), Nan::New("embedded_template").ToLocalChecked());
+  Nan::Set(module, Nan::New("exports").ToLocalChecked(), instance);
 }
 
 NODE_MODULE(tree_sitter_embedded_template_binding, Init)


### PR DESCRIPTION
The following changes were made to this repo:
- `Local` was used instead of `Handle`
- `Nan::GetFunction(tpl).ToLocalChecked()` instead of `tpl->GetFunction()`
- `Nan::Set()` was used instead of  `instance->Set()`
-------
Fixes https://github.com/tree-sitter/tree-sitter-embedded-template/issues/3