### PR TITLE
Allow empty directives and turn-off automatic white space handling

### DIFF
--- a/corpus/main.txt
+++ b/corpus/main.txt
@@ -93,3 +93,60 @@ Empty comment
   (content)
   (comment_directive)
   (content))
+
+===============================
+Empty directives
+===============================
+
+<%%>
+<% %>
+<%-%>
+<% -%>
+<%_ %>
+<%_%>
+<%_-%>
+<%__%>
+<%=%>
+<%=-%>
+<%==%>
+<%-%>
+<%--%>
+<%-=%>
+<%#%>
+<%graphql%>
+
+---
+
+(template
+  (content)
+  (directive (code))
+  (content)
+  (output_directive)
+  (content)
+  (directive (code))
+  (content)
+  (directive (code))
+  (content)
+  (directive)
+  (content)
+  (directive)
+  (content)
+  (directive)
+  (content)
+  (output_directive)
+  (content)
+  (output_directive)
+  (content)
+  (output_directive)
+  (content)
+  (output_directive)
+  (content)
+  (output_directive)
+  (content)
+  (output_directive)
+  (content)
+  (comment_directive)
+  (content)
+  (graphql_directive)
+  (content)
+)

--- a/corpus/main.txt
+++ b/corpus/main.txt
@@ -65,6 +65,20 @@ Underscores in code
   (content))
 
 ===============================
+Empty directive
+===============================
+
+<% %>
+  <%= "hello" %>
+
+---
+
+(template 
+  (directive (code))
+  (content)
+) 
+
+===============================
 Empty comment
 ===============================
 

--- a/corpus/main.txt
+++ b/corpus/main.txt
@@ -74,7 +74,10 @@ Empty directive
 ---
 
 (template 
+  (content)
   (directive (code))
+  (content)
+  (output_directive (code))
   (content)
 ) 
 
@@ -82,10 +85,11 @@ Empty directive
 Empty comment
 ===============================
 
-<%# %>
+<%#%>
 
 ---
 
 (template
+  (content)
   (comment_directive)
   (content))

--- a/grammar.js
+++ b/grammar.js
@@ -16,13 +16,13 @@ module.exports = grammar({
 
     directive: $ => seq(
       choice('<%', '<%_'),
-      $.code,
+      optional($.code),
       choice('%>', '-%>', '_%>')
     ),
 
     output_directive: $ => seq(
       choice('<%=', '<%-'),
-      $.code,
+      optional($.code),
       choice('%>', '-%>', '=%>')
     ),
 
@@ -34,7 +34,7 @@ module.exports = grammar({
 
     graphql_directive: $ => seq(
       '<%graphql',
-      $.code,
+      optional($.code),
       '%>'
     )
   }

--- a/grammar.js
+++ b/grammar.js
@@ -1,6 +1,6 @@
 module.exports = grammar({
   name: 'embedded_template',
-
+  extras: $ => [],
   rules: {
     template: $ => repeat(choice(
       $.directive,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -191,12 +191,7 @@
       ]
     }
   },
-  "extras": [
-    {
-      "type": "PATTERN",
-      "value": "\\s"
-    }
-  ],
+  "extras": [],
   "conflicts": [],
   "precedences": [],
   "externals": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -82,8 +82,16 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "code"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "code"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -121,8 +129,16 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "code"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "code"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -181,8 +197,16 @@
           "value": "<%graphql"
         },
         {
-          "type": "SYMBOL",
-          "name": "code"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "code"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -35,7 +35,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "code",
@@ -50,7 +50,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "code",
@@ -65,7 +65,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "code",

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,7 +6,7 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 26
+#define STATE_COUNT 29
 #define LARGE_STATE_COUNT 4
 #define SYMBOL_COUNT 25
 #define ALIAS_COUNT 1
@@ -228,81 +228,79 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(16);
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '-') ADVANCE(20);
-      if (lookahead == '=') ADVANCE(21);
-      if (lookahead == '_') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(23);
+      if (eof) ADVANCE(15);
+      if (lookahead == '%') ADVANCE(17);
+      if (lookahead == '-') ADVANCE(18);
+      if (lookahead == '=') ADVANCE(19);
+      if (lookahead == '_') ADVANCE(20);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 1:
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '-') ADVANCE(20);
-      if (lookahead == '=') ADVANCE(17);
-      if (lookahead == '_') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(23);
+      if (lookahead == '%') ADVANCE(17);
+      if (lookahead == '-') ADVANCE(18);
+      if (lookahead == '=') ADVANCE(16);
+      if (lookahead == '_') ADVANCE(20);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 2:
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '-') ADVANCE(20);
-      if (lookahead == '=') ADVANCE(21);
-      if (lookahead == '_') ADVANCE(17);
-      if (lookahead != 0) ADVANCE(23);
+      if (lookahead == '%') ADVANCE(17);
+      if (lookahead == '-') ADVANCE(18);
+      if (lookahead == '=') ADVANCE(19);
+      if (lookahead == '_') ADVANCE(16);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 3:
-      if (lookahead == '%') ADVANCE(19);
+      if (lookahead == '%') ADVANCE(17);
       if (lookahead == '-' ||
           lookahead == '=' ||
-          lookahead == '_') ADVANCE(17);
-      if (lookahead != 0) ADVANCE(23);
+          lookahead == '_') ADVANCE(16);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 4:
-      if (lookahead == '%') ADVANCE(18);
-      if (lookahead == '-' ||
-          lookahead == '=' ||
-          lookahead == '_') ADVANCE(17);
-      if (lookahead != 0) ADVANCE(23);
+      if (lookahead == '>') ADVANCE(22);
       END_STATE();
     case 5:
-      if (lookahead == '>') ADVANCE(24);
+      if (lookahead == '>') ADVANCE(29);
       END_STATE();
     case 6:
-      if (lookahead == '>') ADVANCE(31);
+      if (lookahead == '>') ADVANCE(33);
       END_STATE();
     case 7:
-      if (lookahead == '>') ADVANCE(35);
+      if (lookahead == '>') ADVANCE(30);
       END_STATE();
     case 8:
-      if (lookahead == '>') ADVANCE(32);
+      if (lookahead == 'a') ADVANCE(11);
       END_STATE();
     case 9:
-      if (lookahead == 'a') ADVANCE(12);
+      if (lookahead == 'h') ADVANCE(12);
       END_STATE();
     case 10:
-      if (lookahead == 'h') ADVANCE(13);
+      if (lookahead == 'l') ADVANCE(35);
       END_STATE();
     case 11:
-      if (lookahead == 'l') ADVANCE(37);
+      if (lookahead == 'p') ADVANCE(9);
       END_STATE();
     case 12:
-      if (lookahead == 'p') ADVANCE(10);
+      if (lookahead == 'q') ADVANCE(10);
       END_STATE();
     case 13:
-      if (lookahead == 'q') ADVANCE(11);
+      if (lookahead == 'r') ADVANCE(8);
       END_STATE();
     case 14:
-      if (lookahead == 'r') ADVANCE(9);
+      if (eof) ADVANCE(15);
+      if (lookahead == '<') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(24);
       END_STATE();
     case 15:
-      if (eof) ADVANCE(16);
-      if (lookahead == '<') ADVANCE(25);
-      if (lookahead != 0) ADVANCE(26);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 16:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      ACCEPT_TOKEN(aux_sym_code_token1);
       END_STATE();
     case 17:
       ACCEPT_TOKEN(aux_sym_code_token1);
+      if (lookahead == '%') ADVANCE(4);
+      if (lookahead == '>') ADVANCE(28);
       END_STATE();
     case 18:
       ACCEPT_TOKEN(aux_sym_code_token1);
@@ -310,78 +308,69 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 19:
       ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(5);
-      if (lookahead == '>') ADVANCE(30);
+      if (lookahead == '%') ADVANCE(6);
       END_STATE();
     case 20:
       ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(6);
-      END_STATE();
-    case 21:
-      ACCEPT_TOKEN(aux_sym_code_token1);
       if (lookahead == '%') ADVANCE(7);
       END_STATE();
-    case 22:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(8);
-      END_STATE();
-    case 23:
+    case 21:
       ACCEPT_TOKEN(aux_sym_code_token1);
       if (lookahead != 0 &&
           lookahead != '%' &&
           lookahead != '-' &&
           lookahead != '=' &&
-          lookahead != '_') ADVANCE(23);
+          lookahead != '_') ADVANCE(21);
       END_STATE();
-    case 24:
+    case 22:
       ACCEPT_TOKEN(anon_sym_PERCENT_PERCENT_GT);
       END_STATE();
-    case 25:
+    case 23:
       ACCEPT_TOKEN(aux_sym_content_token1);
-      if (lookahead == '%') ADVANCE(28);
+      if (lookahead == '%') ADVANCE(26);
       END_STATE();
-    case 26:
+    case 24:
       ACCEPT_TOKEN(aux_sym_content_token1);
       if (lookahead != 0 &&
-          lookahead != '<') ADVANCE(26);
+          lookahead != '<') ADVANCE(24);
       END_STATE();
-    case 27:
+    case 25:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
       END_STATE();
-    case 28:
+    case 26:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT);
-      if (lookahead == '#') ADVANCE(36);
-      if (lookahead == '%') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(34);
-      if (lookahead == '=') ADVANCE(33);
-      if (lookahead == '_') ADVANCE(29);
-      if (lookahead == 'g') ADVANCE(14);
+      if (lookahead == '#') ADVANCE(34);
+      if (lookahead == '%') ADVANCE(25);
+      if (lookahead == '-') ADVANCE(32);
+      if (lookahead == '=') ADVANCE(31);
+      if (lookahead == '_') ADVANCE(27);
+      if (lookahead == 'g') ADVANCE(13);
       END_STATE();
-    case 29:
+    case 27:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_);
       END_STATE();
-    case 30:
+    case 28:
       ACCEPT_TOKEN(anon_sym_PERCENT_GT);
       END_STATE();
-    case 31:
+    case 29:
       ACCEPT_TOKEN(anon_sym_DASH_PERCENT_GT);
       END_STATE();
-    case 32:
+    case 30:
       ACCEPT_TOKEN(anon_sym__PERCENT_GT);
       END_STATE();
-    case 33:
+    case 31:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
       END_STATE();
-    case 34:
+    case 32:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_DASH);
       END_STATE();
-    case 35:
+    case 33:
       ACCEPT_TOKEN(anon_sym_EQ_PERCENT_GT);
       END_STATE();
-    case 36:
+    case 34:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
       END_STATE();
-    case 37:
+    case 35:
       ACCEPT_TOKEN(anon_sym_LT_PERCENTgraphql);
       END_STATE();
     default:
@@ -391,31 +380,34 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 15},
-  [2] = {.lex_state = 15},
-  [3] = {.lex_state = 15},
-  [4] = {.lex_state = 15},
-  [5] = {.lex_state = 15},
-  [6] = {.lex_state = 15},
-  [7] = {.lex_state = 15},
-  [8] = {.lex_state = 15},
-  [9] = {.lex_state = 15},
-  [10] = {.lex_state = 15},
-  [11] = {.lex_state = 1},
-  [12] = {.lex_state = 1},
-  [13] = {.lex_state = 2},
-  [14] = {.lex_state = 2},
-  [15] = {.lex_state = 3},
-  [16] = {.lex_state = 4},
-  [17] = {.lex_state = 4},
-  [18] = {.lex_state = 4},
-  [19] = {.lex_state = 3},
+  [1] = {.lex_state = 14},
+  [2] = {.lex_state = 14},
+  [3] = {.lex_state = 14},
+  [4] = {.lex_state = 14},
+  [5] = {.lex_state = 14},
+  [6] = {.lex_state = 14},
+  [7] = {.lex_state = 14},
+  [8] = {.lex_state = 14},
+  [9] = {.lex_state = 14},
+  [10] = {.lex_state = 14},
+  [11] = {.lex_state = 14},
+  [12] = {.lex_state = 14},
+  [13] = {.lex_state = 14},
+  [14] = {.lex_state = 1},
+  [15] = {.lex_state = 2},
+  [16] = {.lex_state = 1},
+  [17] = {.lex_state = 1},
+  [18] = {.lex_state = 2},
+  [19] = {.lex_state = 2},
   [20] = {.lex_state = 3},
-  [21] = {.lex_state = 0},
-  [22] = {.lex_state = 0},
-  [23] = {.lex_state = 0},
+  [21] = {.lex_state = 3},
+  [22] = {.lex_state = 3},
+  [23] = {.lex_state = 3},
   [24] = {.lex_state = 0},
   [25] = {.lex_state = 0},
+  [26] = {.lex_state = 0},
+  [27] = {.lex_state = 0},
+  [28] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -429,13 +421,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_EQ_PERCENT_GT] = ACTIONS(1),
   },
   [1] = {
-    [sym_template] = STATE(25),
-    [sym_content] = STATE(2),
-    [sym_directive] = STATE(2),
-    [sym_output_directive] = STATE(2),
-    [sym_comment_directive] = STATE(2),
-    [sym_graphql_directive] = STATE(2),
-    [aux_sym_template_repeat1] = STATE(2),
+    [sym_template] = STATE(28),
+    [sym_content] = STATE(3),
+    [sym_directive] = STATE(3),
+    [sym_output_directive] = STATE(3),
+    [sym_comment_directive] = STATE(3),
+    [sym_graphql_directive] = STATE(3),
+    [aux_sym_template_repeat1] = STATE(3),
     [aux_sym_content_repeat1] = STATE(4),
     [ts_builtin_sym_end] = ACTIONS(3),
     [aux_sym_content_token1] = ACTIONS(5),
@@ -448,14 +440,32 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LT_PERCENTgraphql] = ACTIONS(17),
   },
   [2] = {
-    [sym_content] = STATE(3),
-    [sym_directive] = STATE(3),
-    [sym_output_directive] = STATE(3),
-    [sym_comment_directive] = STATE(3),
-    [sym_graphql_directive] = STATE(3),
-    [aux_sym_template_repeat1] = STATE(3),
+    [sym_content] = STATE(2),
+    [sym_directive] = STATE(2),
+    [sym_output_directive] = STATE(2),
+    [sym_comment_directive] = STATE(2),
+    [sym_graphql_directive] = STATE(2),
+    [aux_sym_template_repeat1] = STATE(2),
     [aux_sym_content_repeat1] = STATE(4),
     [ts_builtin_sym_end] = ACTIONS(19),
+    [aux_sym_content_token1] = ACTIONS(21),
+    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(24),
+    [anon_sym_LT_PERCENT] = ACTIONS(27),
+    [anon_sym_LT_PERCENT_] = ACTIONS(30),
+    [anon_sym_LT_PERCENT_EQ] = ACTIONS(33),
+    [anon_sym_LT_PERCENT_DASH] = ACTIONS(33),
+    [anon_sym_LT_PERCENT_POUND] = ACTIONS(36),
+    [anon_sym_LT_PERCENTgraphql] = ACTIONS(39),
+  },
+  [3] = {
+    [sym_content] = STATE(2),
+    [sym_directive] = STATE(2),
+    [sym_output_directive] = STATE(2),
+    [sym_comment_directive] = STATE(2),
+    [sym_graphql_directive] = STATE(2),
+    [aux_sym_template_repeat1] = STATE(2),
+    [aux_sym_content_repeat1] = STATE(4),
+    [ts_builtin_sym_end] = ACTIONS(42),
     [aux_sym_content_token1] = ACTIONS(5),
     [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(7),
     [anon_sym_LT_PERCENT] = ACTIONS(9),
@@ -464,24 +474,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LT_PERCENT_DASH] = ACTIONS(13),
     [anon_sym_LT_PERCENT_POUND] = ACTIONS(15),
     [anon_sym_LT_PERCENTgraphql] = ACTIONS(17),
-  },
-  [3] = {
-    [sym_content] = STATE(3),
-    [sym_directive] = STATE(3),
-    [sym_output_directive] = STATE(3),
-    [sym_comment_directive] = STATE(3),
-    [sym_graphql_directive] = STATE(3),
-    [aux_sym_template_repeat1] = STATE(3),
-    [aux_sym_content_repeat1] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(21),
-    [aux_sym_content_token1] = ACTIONS(23),
-    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(26),
-    [anon_sym_LT_PERCENT] = ACTIONS(29),
-    [anon_sym_LT_PERCENT_] = ACTIONS(32),
-    [anon_sym_LT_PERCENT_EQ] = ACTIONS(35),
-    [anon_sym_LT_PERCENT_DASH] = ACTIONS(35),
-    [anon_sym_LT_PERCENT_POUND] = ACTIONS(38),
-    [anon_sym_LT_PERCENTgraphql] = ACTIONS(41),
   },
 };
 
@@ -578,124 +570,170 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_DASH,
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENTgraphql,
-  [112] = 4,
-    ACTIONS(82), 1,
+  [112] = 2,
+    ACTIONS(84), 2,
+      aux_sym_content_token1,
+      anon_sym_LT_PERCENT,
+    ACTIONS(82), 7,
+      ts_builtin_sym_end,
+      anon_sym_LT_PERCENT_PERCENT,
+      anon_sym_LT_PERCENT_,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_DASH,
+      anon_sym_LT_PERCENT_POUND,
+      anon_sym_LT_PERCENTgraphql,
+  [126] = 2,
+    ACTIONS(88), 2,
+      aux_sym_content_token1,
+      anon_sym_LT_PERCENT,
+    ACTIONS(86), 7,
+      ts_builtin_sym_end,
+      anon_sym_LT_PERCENT_PERCENT,
+      anon_sym_LT_PERCENT_,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_DASH,
+      anon_sym_LT_PERCENT_POUND,
+      anon_sym_LT_PERCENTgraphql,
+  [140] = 2,
+    ACTIONS(92), 2,
+      aux_sym_content_token1,
+      anon_sym_LT_PERCENT,
+    ACTIONS(90), 7,
+      ts_builtin_sym_end,
+      anon_sym_LT_PERCENT_PERCENT,
+      anon_sym_LT_PERCENT_,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_DASH,
+      anon_sym_LT_PERCENT_POUND,
+      anon_sym_LT_PERCENTgraphql,
+  [154] = 5,
+    ACTIONS(94), 1,
       aux_sym_code_token1,
-    ACTIONS(85), 1,
-      anon_sym_PERCENT_PERCENT_GT,
-    STATE(11), 1,
-      aux_sym_code_repeat1,
-    ACTIONS(88), 3,
-      anon_sym_PERCENT_GT,
-      anon_sym_DASH_PERCENT_GT,
-      anon_sym__PERCENT_GT,
-  [127] = 4,
-    ACTIONS(90), 1,
-      aux_sym_code_token1,
-    ACTIONS(92), 1,
-      anon_sym_PERCENT_PERCENT_GT,
-    STATE(11), 1,
-      aux_sym_code_repeat1,
-    ACTIONS(94), 3,
-      anon_sym_PERCENT_GT,
-      anon_sym_DASH_PERCENT_GT,
-      anon_sym__PERCENT_GT,
-  [142] = 4,
     ACTIONS(96), 1,
-      aux_sym_code_token1,
-    ACTIONS(98), 1,
       anon_sym_PERCENT_PERCENT_GT,
-    STATE(14), 1,
+    STATE(16), 1,
       aux_sym_code_repeat1,
-    ACTIONS(94), 3,
+    STATE(25), 1,
+      sym_code,
+    ACTIONS(98), 3,
       anon_sym_PERCENT_GT,
       anon_sym_DASH_PERCENT_GT,
-      anon_sym_EQ_PERCENT_GT,
-  [157] = 4,
+      anon_sym__PERCENT_GT,
+  [172] = 5,
     ACTIONS(100), 1,
       aux_sym_code_token1,
-    ACTIONS(103), 1,
+    ACTIONS(102), 1,
       anon_sym_PERCENT_PERCENT_GT,
-    STATE(14), 1,
-      aux_sym_code_repeat1,
-    ACTIONS(88), 3,
-      anon_sym_PERCENT_GT,
-      anon_sym_DASH_PERCENT_GT,
-      anon_sym_EQ_PERCENT_GT,
-  [172] = 5,
-    ACTIONS(106), 1,
-      aux_sym_code_token1,
-    ACTIONS(108), 1,
-      anon_sym_PERCENT_PERCENT_GT,
-    ACTIONS(110), 1,
-      anon_sym_PERCENT_GT,
-    STATE(19), 1,
-      aux_sym_code_repeat1,
-    STATE(23), 1,
-      sym_code,
-  [188] = 4,
-    ACTIONS(112), 1,
-      aux_sym_code_token1,
-    ACTIONS(114), 1,
-      anon_sym_PERCENT_PERCENT_GT,
-    STATE(12), 1,
-      aux_sym_code_repeat1,
-    STATE(22), 1,
-      sym_code,
-  [201] = 4,
-    ACTIONS(106), 1,
-      aux_sym_code_token1,
-    ACTIONS(108), 1,
-      anon_sym_PERCENT_PERCENT_GT,
-    STATE(19), 1,
+    STATE(18), 1,
       aux_sym_code_repeat1,
     STATE(24), 1,
       sym_code,
-  [214] = 4,
-    ACTIONS(116), 1,
-      aux_sym_code_token1,
-    ACTIONS(118), 1,
-      anon_sym_PERCENT_PERCENT_GT,
-    STATE(13), 1,
-      aux_sym_code_repeat1,
-    STATE(21), 1,
-      sym_code,
-  [227] = 4,
-    ACTIONS(94), 1,
+    ACTIONS(104), 3,
       anon_sym_PERCENT_GT,
+      anon_sym_DASH_PERCENT_GT,
+      anon_sym_EQ_PERCENT_GT,
+  [190] = 4,
+    ACTIONS(106), 1,
+      aux_sym_code_token1,
+    ACTIONS(108), 1,
+      anon_sym_PERCENT_PERCENT_GT,
+    STATE(17), 1,
+      aux_sym_code_repeat1,
+    ACTIONS(110), 3,
+      anon_sym_PERCENT_GT,
+      anon_sym_DASH_PERCENT_GT,
+      anon_sym__PERCENT_GT,
+  [205] = 4,
+    ACTIONS(112), 1,
+      aux_sym_code_token1,
+    ACTIONS(115), 1,
+      anon_sym_PERCENT_PERCENT_GT,
+    STATE(17), 1,
+      aux_sym_code_repeat1,
+    ACTIONS(118), 3,
+      anon_sym_PERCENT_GT,
+      anon_sym_DASH_PERCENT_GT,
+      anon_sym__PERCENT_GT,
+  [220] = 4,
     ACTIONS(120), 1,
       aux_sym_code_token1,
     ACTIONS(122), 1,
       anon_sym_PERCENT_PERCENT_GT,
-    STATE(20), 1,
+    STATE(19), 1,
       aux_sym_code_repeat1,
-  [240] = 4,
-    ACTIONS(88), 1,
+    ACTIONS(110), 3,
       anon_sym_PERCENT_GT,
+      anon_sym_DASH_PERCENT_GT,
+      anon_sym_EQ_PERCENT_GT,
+  [235] = 4,
     ACTIONS(124), 1,
       aux_sym_code_token1,
     ACTIONS(127), 1,
       anon_sym_PERCENT_PERCENT_GT,
-    STATE(20), 1,
+    STATE(19), 1,
       aux_sym_code_repeat1,
-  [253] = 1,
-    ACTIONS(130), 3,
+    ACTIONS(118), 3,
       anon_sym_PERCENT_GT,
       anon_sym_DASH_PERCENT_GT,
       anon_sym_EQ_PERCENT_GT,
-  [259] = 1,
-    ACTIONS(132), 3,
+  [250] = 5,
+    ACTIONS(130), 1,
+      aux_sym_code_token1,
+    ACTIONS(132), 1,
+      anon_sym_PERCENT_PERCENT_GT,
+    ACTIONS(134), 1,
+      anon_sym_PERCENT_GT,
+    STATE(22), 1,
+      aux_sym_code_repeat1,
+    STATE(26), 1,
+      sym_code,
+  [266] = 5,
+    ACTIONS(130), 1,
+      aux_sym_code_token1,
+    ACTIONS(132), 1,
+      anon_sym_PERCENT_PERCENT_GT,
+    ACTIONS(136), 1,
+      anon_sym_PERCENT_GT,
+    STATE(22), 1,
+      aux_sym_code_repeat1,
+    STATE(27), 1,
+      sym_code,
+  [282] = 4,
+    ACTIONS(110), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(138), 1,
+      aux_sym_code_token1,
+    ACTIONS(140), 1,
+      anon_sym_PERCENT_PERCENT_GT,
+    STATE(23), 1,
+      aux_sym_code_repeat1,
+  [295] = 4,
+    ACTIONS(118), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(142), 1,
+      aux_sym_code_token1,
+    ACTIONS(145), 1,
+      anon_sym_PERCENT_PERCENT_GT,
+    STATE(23), 1,
+      aux_sym_code_repeat1,
+  [308] = 1,
+    ACTIONS(148), 3,
+      anon_sym_PERCENT_GT,
+      anon_sym_DASH_PERCENT_GT,
+      anon_sym_EQ_PERCENT_GT,
+  [314] = 1,
+    ACTIONS(150), 3,
       anon_sym_PERCENT_GT,
       anon_sym_DASH_PERCENT_GT,
       anon_sym__PERCENT_GT,
-  [265] = 1,
-    ACTIONS(134), 1,
+  [320] = 1,
+    ACTIONS(152), 1,
       anon_sym_PERCENT_GT,
-  [269] = 1,
-    ACTIONS(136), 1,
+  [324] = 1,
+    ACTIONS(154), 1,
       anon_sym_PERCENT_GT,
-  [273] = 1,
-    ACTIONS(138), 1,
+  [328] = 1,
+    ACTIONS(156), 1,
       ts_builtin_sym_end,
 };
 
@@ -708,20 +746,23 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(9)] = 84,
   [SMALL_STATE(10)] = 98,
   [SMALL_STATE(11)] = 112,
-  [SMALL_STATE(12)] = 127,
-  [SMALL_STATE(13)] = 142,
-  [SMALL_STATE(14)] = 157,
+  [SMALL_STATE(12)] = 126,
+  [SMALL_STATE(13)] = 140,
+  [SMALL_STATE(14)] = 154,
   [SMALL_STATE(15)] = 172,
-  [SMALL_STATE(16)] = 188,
-  [SMALL_STATE(17)] = 201,
-  [SMALL_STATE(18)] = 214,
-  [SMALL_STATE(19)] = 227,
-  [SMALL_STATE(20)] = 240,
-  [SMALL_STATE(21)] = 253,
-  [SMALL_STATE(22)] = 259,
-  [SMALL_STATE(23)] = 265,
-  [SMALL_STATE(24)] = 269,
-  [SMALL_STATE(25)] = 273,
+  [SMALL_STATE(16)] = 190,
+  [SMALL_STATE(17)] = 205,
+  [SMALL_STATE(18)] = 220,
+  [SMALL_STATE(19)] = 235,
+  [SMALL_STATE(20)] = 250,
+  [SMALL_STATE(21)] = 266,
+  [SMALL_STATE(22)] = 282,
+  [SMALL_STATE(23)] = 295,
+  [SMALL_STATE(24)] = 308,
+  [SMALL_STATE(25)] = 314,
+  [SMALL_STATE(26)] = 320,
+  [SMALL_STATE(27)] = 324,
+  [SMALL_STATE(28)] = 328,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -730,20 +771,20 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_template, 0),
   [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_template, 1),
-  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2),
-  [23] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(4),
-  [26] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(4),
-  [29] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(16),
-  [32] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(16),
-  [35] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(18),
-  [38] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(15),
-  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(17),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2),
+  [21] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(4),
+  [24] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(4),
+  [27] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(14),
+  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(14),
+  [33] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(15),
+  [36] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(20),
+  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(21),
+  [42] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_template, 1),
   [44] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_content, 1),
   [46] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
   [48] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
@@ -754,40 +795,49 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [60] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2),
   [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_directive, 2),
   [64] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_directive, 2),
-  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_directive, 3),
-  [68] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_directive, 3),
-  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_directive, 3, .production_id = 1),
-  [72] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_directive, 3, .production_id = 1),
-  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_output_directive, 3),
-  [76] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_output_directive, 3),
-  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
-  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(11),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(11),
-  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2),
-  [90] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_code, 1),
-  [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
-  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [100] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(14),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(14),
-  [106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [112] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
-  [114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [116] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
-  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [124] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(20),
-  [127] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(20),
-  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [138] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_output_directive, 3),
+  [68] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_output_directive, 3),
+  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_directive, 3),
+  [72] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_directive, 3),
+  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 2),
+  [76] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 2),
+  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_directive, 3, .production_id = 1),
+  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_directive, 3, .production_id = 1),
+  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
+  [84] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
+  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_output_directive, 2),
+  [88] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_output_directive, 2),
+  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_directive, 2),
+  [92] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_directive, 2),
+  [94] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
+  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [100] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_code, 1),
+  [112] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(17),
+  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(17),
+  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2),
+  [120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [124] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(19),
+  [127] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(19),
+  [130] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [138] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [142] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(23),
+  [145] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(23),
+  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [156] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -44,7 +44,7 @@ enum {
   alias_sym_comment = 25,
 };
 
-static const char *ts_symbol_names[] = {
+static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [aux_sym_code_token1] = "code_token1",
   [anon_sym_PERCENT_PERCENT_GT] = "%%>",
@@ -73,7 +73,7 @@ static const char *ts_symbol_names[] = {
   [alias_sym_comment] = "comment",
 };
 
-static TSSymbol ts_symbol_map[] = {
+static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [aux_sym_code_token1] = aux_sym_code_token1,
   [anon_sym_PERCENT_PERCENT_GT] = anon_sym_PERCENT_PERCENT_GT,
@@ -209,14 +209,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
 };
 
-static TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
   [1] = {
     [1] = alias_sym_comment,
   },
 };
 
-static uint16_t ts_non_terminal_alias_map[] = {
+static const uint16_t ts_non_terminal_alias_map[] = {
   sym_code, 2,
     sym_code,
     alias_sym_comment,
@@ -228,257 +228,160 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(21);
-      if (lookahead == '%') ADVANCE(1);
-      if (lookahead == '-') ADVANCE(6);
-      if (lookahead == '<') ADVANCE(2);
-      if (lookahead == '=') ADVANCE(8);
-      if (lookahead == '_') ADVANCE(9);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(0)
+      if (eof) ADVANCE(16);
+      if (lookahead == '%') ADVANCE(19);
+      if (lookahead == '-') ADVANCE(20);
+      if (lookahead == '=') ADVANCE(21);
+      if (lookahead == '_') ADVANCE(22);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 1:
-      if (lookahead == '%') ADVANCE(10);
-      if (lookahead == '>') ADVANCE(40);
+      if (lookahead == '%') ADVANCE(19);
+      if (lookahead == '-') ADVANCE(20);
+      if (lookahead == '=') ADVANCE(17);
+      if (lookahead == '_') ADVANCE(22);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 2:
-      if (lookahead == '%') ADVANCE(38);
+      if (lookahead == '%') ADVANCE(19);
+      if (lookahead == '-') ADVANCE(20);
+      if (lookahead == '=') ADVANCE(21);
+      if (lookahead == '_') ADVANCE(17);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 3:
-      if (lookahead == '%') ADVANCE(24);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '=') ADVANCE(22);
-      if (lookahead == '_') ADVANCE(31);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(25);
-      if (lookahead != 0) ADVANCE(32);
+      if (lookahead == '%') ADVANCE(19);
+      if (lookahead == '-' ||
+          lookahead == '=' ||
+          lookahead == '_') ADVANCE(17);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 4:
-      if (lookahead == '%') ADVANCE(24);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '=') ADVANCE(30);
-      if (lookahead == '_') ADVANCE(22);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(26);
-      if (lookahead != 0) ADVANCE(32);
+      if (lookahead == '%') ADVANCE(18);
+      if (lookahead == '-' ||
+          lookahead == '=' ||
+          lookahead == '_') ADVANCE(17);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
     case 5:
-      if (lookahead == '%') ADVANCE(24);
-      if (lookahead == '-' ||
-          lookahead == '=' ||
-          lookahead == '_') ADVANCE(22);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(27);
-      if (lookahead != 0) ADVANCE(32);
+      if (lookahead == '>') ADVANCE(24);
       END_STATE();
     case 6:
-      if (lookahead == '%') ADVANCE(11);
+      if (lookahead == '>') ADVANCE(31);
       END_STATE();
     case 7:
-      if (lookahead == '%') ADVANCE(23);
-      if (lookahead == '-' ||
-          lookahead == '=' ||
-          lookahead == '_') ADVANCE(22);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(29);
-      if (lookahead != 0) ADVANCE(32);
+      if (lookahead == '>') ADVANCE(35);
       END_STATE();
     case 8:
-      if (lookahead == '%') ADVANCE(12);
+      if (lookahead == '>') ADVANCE(32);
       END_STATE();
     case 9:
-      if (lookahead == '%') ADVANCE(13);
+      if (lookahead == 'a') ADVANCE(12);
       END_STATE();
     case 10:
-      if (lookahead == '>') ADVANCE(33);
+      if (lookahead == 'h') ADVANCE(13);
       END_STATE();
     case 11:
-      if (lookahead == '>') ADVANCE(41);
+      if (lookahead == 'l') ADVANCE(37);
       END_STATE();
     case 12:
-      if (lookahead == '>') ADVANCE(45);
+      if (lookahead == 'p') ADVANCE(10);
       END_STATE();
     case 13:
-      if (lookahead == '>') ADVANCE(42);
+      if (lookahead == 'q') ADVANCE(11);
       END_STATE();
     case 14:
-      if (lookahead == 'a') ADVANCE(17);
+      if (lookahead == 'r') ADVANCE(9);
       END_STATE();
     case 15:
-      if (lookahead == 'h') ADVANCE(18);
+      if (eof) ADVANCE(16);
+      if (lookahead == '<') ADVANCE(25);
+      if (lookahead != 0) ADVANCE(26);
       END_STATE();
     case 16:
-      if (lookahead == 'l') ADVANCE(47);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 17:
-      if (lookahead == 'p') ADVANCE(15);
+      ACCEPT_TOKEN(aux_sym_code_token1);
       END_STATE();
     case 18:
-      if (lookahead == 'q') ADVANCE(16);
+      ACCEPT_TOKEN(aux_sym_code_token1);
+      if (lookahead == '%') ADVANCE(5);
       END_STATE();
     case 19:
-      if (lookahead == 'r') ADVANCE(14);
+      ACCEPT_TOKEN(aux_sym_code_token1);
+      if (lookahead == '%') ADVANCE(5);
+      if (lookahead == '>') ADVANCE(30);
       END_STATE();
     case 20:
-      if (eof) ADVANCE(21);
-      if (lookahead == '<') ADVANCE(34);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(35);
-      if (lookahead != 0) ADVANCE(36);
+      ACCEPT_TOKEN(aux_sym_code_token1);
+      if (lookahead == '%') ADVANCE(6);
       END_STATE();
     case 21:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      ACCEPT_TOKEN(aux_sym_code_token1);
+      if (lookahead == '%') ADVANCE(7);
       END_STATE();
     case 22:
       ACCEPT_TOKEN(aux_sym_code_token1);
+      if (lookahead == '%') ADVANCE(8);
       END_STATE();
     case 23:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(10);
-      END_STATE();
-    case 24:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(10);
-      if (lookahead == '>') ADVANCE(40);
-      END_STATE();
-    case 25:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(24);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '=') ADVANCE(22);
-      if (lookahead == '_') ADVANCE(31);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(25);
-      if (lookahead != 0) ADVANCE(32);
-      END_STATE();
-    case 26:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(24);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '=') ADVANCE(30);
-      if (lookahead == '_') ADVANCE(22);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(26);
-      if (lookahead != 0) ADVANCE(32);
-      END_STATE();
-    case 27:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(24);
-      if (lookahead == '-' ||
-          lookahead == '=' ||
-          lookahead == '_') ADVANCE(22);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(27);
-      if (lookahead != 0) ADVANCE(32);
-      END_STATE();
-    case 28:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(11);
-      END_STATE();
-    case 29:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(23);
-      if (lookahead == '-' ||
-          lookahead == '=' ||
-          lookahead == '_') ADVANCE(22);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(29);
-      if (lookahead != 0) ADVANCE(32);
-      END_STATE();
-    case 30:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(12);
-      END_STATE();
-    case 31:
-      ACCEPT_TOKEN(aux_sym_code_token1);
-      if (lookahead == '%') ADVANCE(13);
-      END_STATE();
-    case 32:
       ACCEPT_TOKEN(aux_sym_code_token1);
       if (lookahead != 0 &&
           lookahead != '%' &&
           lookahead != '-' &&
           lookahead != '=' &&
-          lookahead != '_') ADVANCE(32);
+          lookahead != '_') ADVANCE(23);
       END_STATE();
-    case 33:
+    case 24:
       ACCEPT_TOKEN(anon_sym_PERCENT_PERCENT_GT);
       END_STATE();
-    case 34:
+    case 25:
       ACCEPT_TOKEN(aux_sym_content_token1);
-      if (lookahead == '%') ADVANCE(38);
+      if (lookahead == '%') ADVANCE(28);
       END_STATE();
-    case 35:
-      ACCEPT_TOKEN(aux_sym_content_token1);
-      if (lookahead == '<') ADVANCE(34);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(35);
-      if (lookahead != 0) ADVANCE(36);
-      END_STATE();
-    case 36:
+    case 26:
       ACCEPT_TOKEN(aux_sym_content_token1);
       if (lookahead != 0 &&
-          lookahead != '<') ADVANCE(36);
+          lookahead != '<') ADVANCE(26);
       END_STATE();
-    case 37:
+    case 27:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
       END_STATE();
-    case 38:
+    case 28:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT);
-      if (lookahead == '#') ADVANCE(46);
-      if (lookahead == '%') ADVANCE(37);
-      if (lookahead == '-') ADVANCE(44);
-      if (lookahead == '=') ADVANCE(43);
-      if (lookahead == '_') ADVANCE(39);
-      if (lookahead == 'g') ADVANCE(19);
+      if (lookahead == '#') ADVANCE(36);
+      if (lookahead == '%') ADVANCE(27);
+      if (lookahead == '-') ADVANCE(34);
+      if (lookahead == '=') ADVANCE(33);
+      if (lookahead == '_') ADVANCE(29);
+      if (lookahead == 'g') ADVANCE(14);
       END_STATE();
-    case 39:
+    case 29:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_);
       END_STATE();
-    case 40:
+    case 30:
       ACCEPT_TOKEN(anon_sym_PERCENT_GT);
       END_STATE();
-    case 41:
+    case 31:
       ACCEPT_TOKEN(anon_sym_DASH_PERCENT_GT);
       END_STATE();
-    case 42:
+    case 32:
       ACCEPT_TOKEN(anon_sym__PERCENT_GT);
       END_STATE();
-    case 43:
+    case 33:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
       END_STATE();
-    case 44:
+    case 34:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_DASH);
       END_STATE();
-    case 45:
+    case 35:
       ACCEPT_TOKEN(anon_sym_EQ_PERCENT_GT);
       END_STATE();
-    case 46:
+    case 36:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
       END_STATE();
-    case 47:
+    case 37:
       ACCEPT_TOKEN(anon_sym_LT_PERCENTgraphql);
       END_STATE();
     default:
@@ -486,28 +389,28 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   }
 }
 
-static TSLexMode ts_lex_modes[STATE_COUNT] = {
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 20},
-  [2] = {.lex_state = 20},
-  [3] = {.lex_state = 20},
-  [4] = {.lex_state = 20},
-  [5] = {.lex_state = 20},
-  [6] = {.lex_state = 20},
-  [7] = {.lex_state = 20},
-  [8] = {.lex_state = 20},
-  [9] = {.lex_state = 20},
-  [10] = {.lex_state = 20},
-  [11] = {.lex_state = 3},
-  [12] = {.lex_state = 3},
-  [13] = {.lex_state = 4},
-  [14] = {.lex_state = 4},
-  [15] = {.lex_state = 5},
-  [16] = {.lex_state = 7},
-  [17] = {.lex_state = 7},
-  [18] = {.lex_state = 7},
-  [19] = {.lex_state = 5},
-  [20] = {.lex_state = 5},
+  [1] = {.lex_state = 15},
+  [2] = {.lex_state = 15},
+  [3] = {.lex_state = 15},
+  [4] = {.lex_state = 15},
+  [5] = {.lex_state = 15},
+  [6] = {.lex_state = 15},
+  [7] = {.lex_state = 15},
+  [8] = {.lex_state = 15},
+  [9] = {.lex_state = 15},
+  [10] = {.lex_state = 15},
+  [11] = {.lex_state = 1},
+  [12] = {.lex_state = 1},
+  [13] = {.lex_state = 2},
+  [14] = {.lex_state = 2},
+  [15] = {.lex_state = 3},
+  [16] = {.lex_state = 4},
+  [17] = {.lex_state = 4},
+  [18] = {.lex_state = 4},
+  [19] = {.lex_state = 3},
+  [20] = {.lex_state = 3},
   [21] = {.lex_state = 0},
   [22] = {.lex_state = 0},
   [23] = {.lex_state = 0},
@@ -515,21 +418,15 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [25] = {.lex_state = 0},
 };
 
-static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
+static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
+    [aux_sym_code_token1] = ACTIONS(1),
     [anon_sym_PERCENT_PERCENT_GT] = ACTIONS(1),
-    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(1),
-    [anon_sym_LT_PERCENT] = ACTIONS(1),
-    [anon_sym_LT_PERCENT_] = ACTIONS(1),
     [anon_sym_PERCENT_GT] = ACTIONS(1),
     [anon_sym_DASH_PERCENT_GT] = ACTIONS(1),
     [anon_sym__PERCENT_GT] = ACTIONS(1),
-    [anon_sym_LT_PERCENT_EQ] = ACTIONS(1),
-    [anon_sym_LT_PERCENT_DASH] = ACTIONS(1),
     [anon_sym_EQ_PERCENT_GT] = ACTIONS(1),
-    [anon_sym_LT_PERCENT_POUND] = ACTIONS(1),
-    [anon_sym_LT_PERCENTgraphql] = ACTIONS(1),
   },
   [1] = {
     [sym_template] = STATE(25),
@@ -542,13 +439,13 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_content_repeat1] = STATE(4),
     [ts_builtin_sym_end] = ACTIONS(3),
     [aux_sym_content_token1] = ACTIONS(5),
-    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(5),
-    [anon_sym_LT_PERCENT] = ACTIONS(7),
-    [anon_sym_LT_PERCENT_] = ACTIONS(7),
-    [anon_sym_LT_PERCENT_EQ] = ACTIONS(9),
-    [anon_sym_LT_PERCENT_DASH] = ACTIONS(9),
-    [anon_sym_LT_PERCENT_POUND] = ACTIONS(11),
-    [anon_sym_LT_PERCENTgraphql] = ACTIONS(13),
+    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(7),
+    [anon_sym_LT_PERCENT] = ACTIONS(9),
+    [anon_sym_LT_PERCENT_] = ACTIONS(11),
+    [anon_sym_LT_PERCENT_EQ] = ACTIONS(13),
+    [anon_sym_LT_PERCENT_DASH] = ACTIONS(13),
+    [anon_sym_LT_PERCENT_POUND] = ACTIONS(15),
+    [anon_sym_LT_PERCENTgraphql] = ACTIONS(17),
   },
   [2] = {
     [sym_content] = STATE(3),
@@ -558,15 +455,15 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_graphql_directive] = STATE(3),
     [aux_sym_template_repeat1] = STATE(3),
     [aux_sym_content_repeat1] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(15),
+    [ts_builtin_sym_end] = ACTIONS(19),
     [aux_sym_content_token1] = ACTIONS(5),
-    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(5),
-    [anon_sym_LT_PERCENT] = ACTIONS(7),
-    [anon_sym_LT_PERCENT_] = ACTIONS(7),
-    [anon_sym_LT_PERCENT_EQ] = ACTIONS(9),
-    [anon_sym_LT_PERCENT_DASH] = ACTIONS(9),
-    [anon_sym_LT_PERCENT_POUND] = ACTIONS(11),
-    [anon_sym_LT_PERCENTgraphql] = ACTIONS(13),
+    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(7),
+    [anon_sym_LT_PERCENT] = ACTIONS(9),
+    [anon_sym_LT_PERCENT_] = ACTIONS(11),
+    [anon_sym_LT_PERCENT_EQ] = ACTIONS(13),
+    [anon_sym_LT_PERCENT_DASH] = ACTIONS(13),
+    [anon_sym_LT_PERCENT_POUND] = ACTIONS(15),
+    [anon_sym_LT_PERCENTgraphql] = ACTIONS(17),
   },
   [3] = {
     [sym_content] = STATE(3),
@@ -576,294 +473,321 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_graphql_directive] = STATE(3),
     [aux_sym_template_repeat1] = STATE(3),
     [aux_sym_content_repeat1] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(17),
-    [aux_sym_content_token1] = ACTIONS(19),
-    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(19),
-    [anon_sym_LT_PERCENT] = ACTIONS(22),
-    [anon_sym_LT_PERCENT_] = ACTIONS(22),
-    [anon_sym_LT_PERCENT_EQ] = ACTIONS(25),
-    [anon_sym_LT_PERCENT_DASH] = ACTIONS(25),
-    [anon_sym_LT_PERCENT_POUND] = ACTIONS(28),
-    [anon_sym_LT_PERCENTgraphql] = ACTIONS(31),
+    [ts_builtin_sym_end] = ACTIONS(21),
+    [aux_sym_content_token1] = ACTIONS(23),
+    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(26),
+    [anon_sym_LT_PERCENT] = ACTIONS(29),
+    [anon_sym_LT_PERCENT_] = ACTIONS(32),
+    [anon_sym_LT_PERCENT_EQ] = ACTIONS(35),
+    [anon_sym_LT_PERCENT_DASH] = ACTIONS(35),
+    [anon_sym_LT_PERCENT_POUND] = ACTIONS(38),
+    [anon_sym_LT_PERCENTgraphql] = ACTIONS(41),
   },
 };
 
-static uint16_t ts_small_parse_table[] = {
-  [0] = 4,
-    ACTIONS(34), 1,
-      ts_builtin_sym_end,
+static const uint16_t ts_small_parse_table[] = {
+  [0] = 5,
+    ACTIONS(46), 1,
+      aux_sym_content_token1,
+    ACTIONS(48), 1,
+      anon_sym_LT_PERCENT_PERCENT,
+    ACTIONS(50), 1,
+      anon_sym_LT_PERCENT,
     STATE(5), 1,
       aux_sym_content_repeat1,
-    ACTIONS(36), 2,
-      aux_sym_content_token1,
-      anon_sym_LT_PERCENT_PERCENT,
-    ACTIONS(38), 6,
-      anon_sym_LT_PERCENT,
+    ACTIONS(44), 6,
+      ts_builtin_sym_end,
       anon_sym_LT_PERCENT_,
       anon_sym_LT_PERCENT_EQ,
       anon_sym_LT_PERCENT_DASH,
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENTgraphql,
-  [19] = 4,
-    ACTIONS(40), 1,
-      ts_builtin_sym_end,
+  [21] = 5,
+    ACTIONS(54), 1,
+      aux_sym_content_token1,
+    ACTIONS(57), 1,
+      anon_sym_LT_PERCENT_PERCENT,
+    ACTIONS(60), 1,
+      anon_sym_LT_PERCENT,
     STATE(5), 1,
       aux_sym_content_repeat1,
-    ACTIONS(42), 2,
-      aux_sym_content_token1,
-      anon_sym_LT_PERCENT_PERCENT,
-    ACTIONS(45), 6,
-      anon_sym_LT_PERCENT,
-      anon_sym_LT_PERCENT_,
-      anon_sym_LT_PERCENT_EQ,
-      anon_sym_LT_PERCENT_DASH,
-      anon_sym_LT_PERCENT_POUND,
-      anon_sym_LT_PERCENTgraphql,
-  [38] = 2,
-    ACTIONS(47), 1,
+    ACTIONS(52), 6,
       ts_builtin_sym_end,
-    ACTIONS(49), 8,
-      aux_sym_content_token1,
-      anon_sym_LT_PERCENT_PERCENT,
-      anon_sym_LT_PERCENT,
       anon_sym_LT_PERCENT_,
       anon_sym_LT_PERCENT_EQ,
       anon_sym_LT_PERCENT_DASH,
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENTgraphql,
-  [52] = 2,
-    ACTIONS(51), 1,
+  [42] = 2,
+    ACTIONS(64), 2,
+      aux_sym_content_token1,
+      anon_sym_LT_PERCENT,
+    ACTIONS(62), 7,
       ts_builtin_sym_end,
-    ACTIONS(53), 8,
-      aux_sym_content_token1,
       anon_sym_LT_PERCENT_PERCENT,
-      anon_sym_LT_PERCENT,
       anon_sym_LT_PERCENT_,
       anon_sym_LT_PERCENT_EQ,
       anon_sym_LT_PERCENT_DASH,
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENTgraphql,
-  [66] = 2,
-    ACTIONS(55), 1,
+  [56] = 2,
+    ACTIONS(68), 2,
+      aux_sym_content_token1,
+      anon_sym_LT_PERCENT,
+    ACTIONS(66), 7,
       ts_builtin_sym_end,
-    ACTIONS(57), 8,
-      aux_sym_content_token1,
       anon_sym_LT_PERCENT_PERCENT,
-      anon_sym_LT_PERCENT,
       anon_sym_LT_PERCENT_,
       anon_sym_LT_PERCENT_EQ,
       anon_sym_LT_PERCENT_DASH,
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENTgraphql,
-  [80] = 2,
-    ACTIONS(59), 1,
-      ts_builtin_sym_end,
-    ACTIONS(61), 8,
-      aux_sym_content_token1,
-      anon_sym_LT_PERCENT_PERCENT,
-      anon_sym_LT_PERCENT,
-      anon_sym_LT_PERCENT_,
-      anon_sym_LT_PERCENT_EQ,
-      anon_sym_LT_PERCENT_DASH,
-      anon_sym_LT_PERCENT_POUND,
-      anon_sym_LT_PERCENTgraphql,
-  [94] = 2,
-    ACTIONS(63), 1,
-      ts_builtin_sym_end,
-    ACTIONS(65), 8,
-      aux_sym_content_token1,
-      anon_sym_LT_PERCENT_PERCENT,
-      anon_sym_LT_PERCENT,
-      anon_sym_LT_PERCENT_,
-      anon_sym_LT_PERCENT_EQ,
-      anon_sym_LT_PERCENT_DASH,
-      anon_sym_LT_PERCENT_POUND,
-      anon_sym_LT_PERCENTgraphql,
-  [108] = 3,
-    STATE(11), 1,
-      aux_sym_code_repeat1,
-    ACTIONS(67), 2,
-      aux_sym_code_token1,
-      anon_sym_PERCENT_PERCENT_GT,
-    ACTIONS(70), 3,
-      anon_sym_PERCENT_GT,
-      anon_sym_DASH_PERCENT_GT,
-      anon_sym__PERCENT_GT,
-  [121] = 3,
-    STATE(11), 1,
-      aux_sym_code_repeat1,
+  [70] = 2,
     ACTIONS(72), 2,
+      aux_sym_content_token1,
+      anon_sym_LT_PERCENT,
+    ACTIONS(70), 7,
+      ts_builtin_sym_end,
+      anon_sym_LT_PERCENT_PERCENT,
+      anon_sym_LT_PERCENT_,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_DASH,
+      anon_sym_LT_PERCENT_POUND,
+      anon_sym_LT_PERCENTgraphql,
+  [84] = 2,
+    ACTIONS(76), 2,
+      aux_sym_content_token1,
+      anon_sym_LT_PERCENT,
+    ACTIONS(74), 7,
+      ts_builtin_sym_end,
+      anon_sym_LT_PERCENT_PERCENT,
+      anon_sym_LT_PERCENT_,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_DASH,
+      anon_sym_LT_PERCENT_POUND,
+      anon_sym_LT_PERCENTgraphql,
+  [98] = 2,
+    ACTIONS(80), 2,
+      aux_sym_content_token1,
+      anon_sym_LT_PERCENT,
+    ACTIONS(78), 7,
+      ts_builtin_sym_end,
+      anon_sym_LT_PERCENT_PERCENT,
+      anon_sym_LT_PERCENT_,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_DASH,
+      anon_sym_LT_PERCENT_POUND,
+      anon_sym_LT_PERCENTgraphql,
+  [112] = 4,
+    ACTIONS(82), 1,
       aux_sym_code_token1,
+    ACTIONS(85), 1,
       anon_sym_PERCENT_PERCENT_GT,
-    ACTIONS(74), 3,
+    STATE(11), 1,
+      aux_sym_code_repeat1,
+    ACTIONS(88), 3,
       anon_sym_PERCENT_GT,
       anon_sym_DASH_PERCENT_GT,
       anon_sym__PERCENT_GT,
-  [134] = 3,
+  [127] = 4,
+    ACTIONS(90), 1,
+      aux_sym_code_token1,
+    ACTIONS(92), 1,
+      anon_sym_PERCENT_PERCENT_GT,
+    STATE(11), 1,
+      aux_sym_code_repeat1,
+    ACTIONS(94), 3,
+      anon_sym_PERCENT_GT,
+      anon_sym_DASH_PERCENT_GT,
+      anon_sym__PERCENT_GT,
+  [142] = 4,
+    ACTIONS(96), 1,
+      aux_sym_code_token1,
+    ACTIONS(98), 1,
+      anon_sym_PERCENT_PERCENT_GT,
     STATE(14), 1,
       aux_sym_code_repeat1,
-    ACTIONS(76), 2,
-      aux_sym_code_token1,
-      anon_sym_PERCENT_PERCENT_GT,
-    ACTIONS(74), 3,
+    ACTIONS(94), 3,
       anon_sym_PERCENT_GT,
       anon_sym_DASH_PERCENT_GT,
       anon_sym_EQ_PERCENT_GT,
-  [147] = 3,
+  [157] = 4,
+    ACTIONS(100), 1,
+      aux_sym_code_token1,
+    ACTIONS(103), 1,
+      anon_sym_PERCENT_PERCENT_GT,
     STATE(14), 1,
       aux_sym_code_repeat1,
-    ACTIONS(78), 2,
-      aux_sym_code_token1,
-      anon_sym_PERCENT_PERCENT_GT,
-    ACTIONS(70), 3,
+    ACTIONS(88), 3,
       anon_sym_PERCENT_GT,
       anon_sym_DASH_PERCENT_GT,
       anon_sym_EQ_PERCENT_GT,
-  [160] = 4,
-    ACTIONS(83), 1,
+  [172] = 5,
+    ACTIONS(106), 1,
+      aux_sym_code_token1,
+    ACTIONS(108), 1,
+      anon_sym_PERCENT_PERCENT_GT,
+    ACTIONS(110), 1,
       anon_sym_PERCENT_GT,
     STATE(19), 1,
       aux_sym_code_repeat1,
     STATE(23), 1,
       sym_code,
-    ACTIONS(81), 2,
+  [188] = 4,
+    ACTIONS(112), 1,
       aux_sym_code_token1,
+    ACTIONS(114), 1,
       anon_sym_PERCENT_PERCENT_GT,
-  [174] = 3,
     STATE(12), 1,
       aux_sym_code_repeat1,
     STATE(22), 1,
       sym_code,
-    ACTIONS(85), 2,
+  [201] = 4,
+    ACTIONS(106), 1,
       aux_sym_code_token1,
+    ACTIONS(108), 1,
       anon_sym_PERCENT_PERCENT_GT,
-  [185] = 3,
     STATE(19), 1,
       aux_sym_code_repeat1,
     STATE(24), 1,
       sym_code,
-    ACTIONS(81), 2,
+  [214] = 4,
+    ACTIONS(116), 1,
       aux_sym_code_token1,
+    ACTIONS(118), 1,
       anon_sym_PERCENT_PERCENT_GT,
-  [196] = 3,
     STATE(13), 1,
       aux_sym_code_repeat1,
     STATE(21), 1,
       sym_code,
-    ACTIONS(87), 2,
-      aux_sym_code_token1,
-      anon_sym_PERCENT_PERCENT_GT,
-  [207] = 3,
-    ACTIONS(74), 1,
+  [227] = 4,
+    ACTIONS(94), 1,
       anon_sym_PERCENT_GT,
+    ACTIONS(120), 1,
+      aux_sym_code_token1,
+    ACTIONS(122), 1,
+      anon_sym_PERCENT_PERCENT_GT,
     STATE(20), 1,
       aux_sym_code_repeat1,
-    ACTIONS(89), 2,
-      aux_sym_code_token1,
-      anon_sym_PERCENT_PERCENT_GT,
-  [218] = 3,
-    ACTIONS(70), 1,
+  [240] = 4,
+    ACTIONS(88), 1,
       anon_sym_PERCENT_GT,
+    ACTIONS(124), 1,
+      aux_sym_code_token1,
+    ACTIONS(127), 1,
+      anon_sym_PERCENT_PERCENT_GT,
     STATE(20), 1,
       aux_sym_code_repeat1,
-    ACTIONS(91), 2,
-      aux_sym_code_token1,
-      anon_sym_PERCENT_PERCENT_GT,
-  [229] = 1,
-    ACTIONS(94), 3,
+  [253] = 1,
+    ACTIONS(130), 3,
       anon_sym_PERCENT_GT,
       anon_sym_DASH_PERCENT_GT,
       anon_sym_EQ_PERCENT_GT,
-  [235] = 1,
-    ACTIONS(96), 3,
+  [259] = 1,
+    ACTIONS(132), 3,
       anon_sym_PERCENT_GT,
       anon_sym_DASH_PERCENT_GT,
       anon_sym__PERCENT_GT,
-  [241] = 1,
-    ACTIONS(98), 1,
+  [265] = 1,
+    ACTIONS(134), 1,
       anon_sym_PERCENT_GT,
-  [245] = 1,
-    ACTIONS(100), 1,
+  [269] = 1,
+    ACTIONS(136), 1,
       anon_sym_PERCENT_GT,
-  [249] = 1,
-    ACTIONS(102), 1,
+  [273] = 1,
+    ACTIONS(138), 1,
       ts_builtin_sym_end,
 };
 
-static uint32_t ts_small_parse_table_map[] = {
+static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(4)] = 0,
-  [SMALL_STATE(5)] = 19,
-  [SMALL_STATE(6)] = 38,
-  [SMALL_STATE(7)] = 52,
-  [SMALL_STATE(8)] = 66,
-  [SMALL_STATE(9)] = 80,
-  [SMALL_STATE(10)] = 94,
-  [SMALL_STATE(11)] = 108,
-  [SMALL_STATE(12)] = 121,
-  [SMALL_STATE(13)] = 134,
-  [SMALL_STATE(14)] = 147,
-  [SMALL_STATE(15)] = 160,
-  [SMALL_STATE(16)] = 174,
-  [SMALL_STATE(17)] = 185,
-  [SMALL_STATE(18)] = 196,
-  [SMALL_STATE(19)] = 207,
-  [SMALL_STATE(20)] = 218,
-  [SMALL_STATE(21)] = 229,
-  [SMALL_STATE(22)] = 235,
-  [SMALL_STATE(23)] = 241,
-  [SMALL_STATE(24)] = 245,
-  [SMALL_STATE(25)] = 249,
+  [SMALL_STATE(5)] = 21,
+  [SMALL_STATE(6)] = 42,
+  [SMALL_STATE(7)] = 56,
+  [SMALL_STATE(8)] = 70,
+  [SMALL_STATE(9)] = 84,
+  [SMALL_STATE(10)] = 98,
+  [SMALL_STATE(11)] = 112,
+  [SMALL_STATE(12)] = 127,
+  [SMALL_STATE(13)] = 142,
+  [SMALL_STATE(14)] = 157,
+  [SMALL_STATE(15)] = 172,
+  [SMALL_STATE(16)] = 188,
+  [SMALL_STATE(17)] = 201,
+  [SMALL_STATE(18)] = 214,
+  [SMALL_STATE(19)] = 227,
+  [SMALL_STATE(20)] = 240,
+  [SMALL_STATE(21)] = 253,
+  [SMALL_STATE(22)] = 259,
+  [SMALL_STATE(23)] = 265,
+  [SMALL_STATE(24)] = 269,
+  [SMALL_STATE(25)] = 273,
 };
 
-static TSParseActionEntry ts_parse_actions[] = {
+static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_template, 0),
   [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_template, 1),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2),
-  [19] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(4),
-  [22] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(16),
-  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(18),
-  [28] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(15),
-  [31] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(17),
-  [34] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_content, 1),
-  [36] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
-  [38] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_content, 1),
-  [40] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2),
-  [42] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(5),
-  [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2),
-  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_directive, 2),
-  [49] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_directive, 2),
-  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_directive, 3),
-  [53] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_directive, 3),
-  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_directive, 3, .production_id = 1),
-  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_directive, 3, .production_id = 1),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_output_directive, 3),
-  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_output_directive, 3),
-  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
-  [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
-  [67] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(11),
-  [70] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2),
-  [72] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [74] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_code, 1),
-  [76] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
-  [78] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(14),
-  [81] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [83] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
-  [85] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
-  [87] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
-  [89] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [91] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(20),
-  [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [102] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_template, 1),
+  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2),
+  [23] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(4),
+  [26] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(4),
+  [29] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(16),
+  [32] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(16),
+  [35] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(18),
+  [38] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(15),
+  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_template_repeat1, 2), SHIFT_REPEAT(17),
+  [44] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_content, 1),
+  [46] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [48] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [50] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_content, 1),
+  [52] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2),
+  [54] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(5),
+  [57] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(5),
+  [60] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2),
+  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_directive, 2),
+  [64] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_directive, 2),
+  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_directive, 3),
+  [68] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_directive, 3),
+  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_directive, 3, .production_id = 1),
+  [72] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_directive, 3, .production_id = 1),
+  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_output_directive, 3),
+  [76] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_output_directive, 3),
+  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
+  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
+  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(11),
+  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(11),
+  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2),
+  [90] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_code, 1),
+  [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [100] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(14),
+  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(14),
+  [106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [112] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [116] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [124] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(20),
+  [127] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_code_repeat1, 2), SHIFT_REPEAT(20),
+  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [138] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus
@@ -874,7 +798,7 @@ extern "C" {
 #endif
 
 extern const TSLanguage *tree_sitter_embedded_template(void) {
-  static TSLanguage language = {
+  static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,
     .alias_count = ALIAS_COUNT,
@@ -885,15 +809,15 @@ extern const TSLanguage *tree_sitter_embedded_template(void) {
     .production_id_count = PRODUCTION_ID_COUNT,
     .field_count = FIELD_COUNT,
     .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
-    .parse_table = (const uint16_t *)ts_parse_table,
-    .small_parse_table = (const uint16_t *)ts_small_parse_table,
-    .small_parse_table_map = (const uint32_t *)ts_small_parse_table_map,
+    .parse_table = &ts_parse_table[0][0],
+    .small_parse_table = ts_small_parse_table,
+    .small_parse_table_map = ts_small_parse_table_map,
     .parse_actions = ts_parse_actions,
     .symbol_names = ts_symbol_names,
     .symbol_metadata = ts_symbol_metadata,
     .public_symbol_map = ts_symbol_map,
     .alias_map = ts_non_terminal_alias_map,
-    .alias_sequences = (const TSSymbol *)ts_alias_sequences,
+    .alias_sequences = &ts_alias_sequences[0][0],
     .lex_modes = ts_lex_modes,
     .lex_fn = ts_lex,
   };

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;


### PR DESCRIPTION
#10 added support for empty comment directives. However, other directives can also be empty. This pull request makes the `$.code` children of those directives optional too.

This pull request also switches of the default handling of whitespace by setting `extras: []` . White space should actually be preserved in ERB as part of the `content` and `code` regions. 