### PR TITLE
Support lua as another embedded template language

### DIFF
--- a/queries/injections-etlua.scm
+++ b/queries/injections-etlua.scm
@@ -1,0 +1,7 @@
+((content) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.combined))
+
+((code) @injection.content
+ (#set! injection.language "lua")
+ (#set! injection.combined))

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -21,6 +21,17 @@
       ],
       "injections": "queries/injections-erb.scm",
       "injection-regex": "erb"
+    },
+    {
+      "name": "embedded-template",
+      "camelcase": "EmbeddedTemplate",
+      "scope": "text.html.etlua",
+      "path": ".",
+      "file-types": [
+        "etlua"
+      ],
+      "injections": "queries/injections-etlua.scm",
+      "injection-regex": "etlua"
     }
   ],
   "metadata": {


### PR DESCRIPTION
Hi, I'm working on a project in the [Lapis](https://leafo.net/lapis/) framework, which uses [`etlua`](https://github.com/leafo/etlua), a lua flavor of embedded templates. Looking over the code, I think this is all that's needed to support lua, sans whatever documentation deserves an update (like the rust stuff).

Happy to make any changes 😄 Thanks for your work.