### PR TITLE
Add headers in python sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft src


### PR DESCRIPTION
Currently only parser.c makes its way to the sdist archive. This prevents anyone that needs to build from source since tree_sitter/parser.h is not in the archive.